### PR TITLE
External Links in Markdown should open in new tab

### DIFF
--- a/packages/ui/Markdown/Markdown.tsx
+++ b/packages/ui/Markdown/Markdown.tsx
@@ -1,3 +1,4 @@
+import { Launch } from "@carbon/icons-react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
@@ -5,7 +6,25 @@ import { markdown } from "./markdown.css";
 
 export const Markdown = ({ children }: { children: string }) => {
   return (
-    <ReactMarkdown className={markdown} remarkPlugins={[remarkGfm]}>
+    <ReactMarkdown
+      className={markdown}
+      remarkPlugins={[remarkGfm]}
+      components={{
+        a: ({ href, children }) => {
+          if (!href) {
+            throw new Error(`Missing href for Markdown Link`);
+          }
+          return (
+            <a href={href} target="_blank" rel="noreferrer">
+              {children}
+              {href.startsWith("http") && (
+                <Launch style={{ fontSize: "1em", display: "inline" }} />
+              )}
+            </a>
+          );
+        },
+      }}
+    >
       {children}
     </ReactMarkdown>
   );


### PR DESCRIPTION
Fixes #180